### PR TITLE
fix: migrateに修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -62,7 +62,7 @@ namespace :deploy do
     on roles(:db) do
       with rails_env: fetch(:rails_env) do
         within release_path do
-          execute :bundle, :exec, :rake, 'db:create'
+          execute :bundle, :exec, :rake, 'db:migrate'
         end
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,7 +58,7 @@ namespace :deploy do
   end
 
   desc 'Create database'
-  task :db_create do
+  task :db_migrate do
     on roles(:db) do
       with rails_env: fetch(:rails_env) do
         within release_path do
@@ -73,5 +73,5 @@ namespace :deploy do
 end
 
 after 'deploy:published', 'nginx:restart'
-before 'deploy:migrate', 'deploy:db_create'
+before 'deploy:migrate', 'deploy:db_migrate'
 before 'bundler:install', 'deploy:config_bundler'


### PR DESCRIPTION
## 概要

deploy.rb内にて、db:createが存在する為、毎回dbが作られてしまっていた。
db:migrateに修正